### PR TITLE
Update TB URL and version

### DIFF
--- a/mykrobe_panels_manifest.json
+++ b/mykrobe_panels_manifest.json
@@ -1,7 +1,7 @@
 {
   "tb": {
-    "url": "https://ndownloader.figshare.com/files/25103438",
-    "version": "20201014"
+    "url": "https://ndownloader.figshare.com/files/36041606",
+    "version": "20220621"
   },
   "staph": {
     "url": "https://ndownloader.figshare.com/files/24914930",


### PR DESCRIPTION
Now points to https://doi.org/10.6084/m9.figshare.20155913.v1, which is the combined WHO and Hunt 2019 panels I built in https://doi.org/10.1016/S2666-5247(22)00151-3 

I've tested this locally and run mykrobe predict after updating the metadata and species.

Of note, mykrobe will now provide calls for Delamanid, Linezolid, Levofloxacin, and Ethionamide. Although performance (sensitivity) for DLM and LZD are not great.